### PR TITLE
MaxConcurrentReconciles for Hbase tenant controller

### DIFF
--- a/operator/controllers/controller_options.go
+++ b/operator/controllers/controller_options.go
@@ -1,0 +1,9 @@
+package controllers
+
+// Options are the config parameters for the controller
+type Options struct {
+
+	// number of reconcilers to run concurrently
+	// multiple resources processed simultaneously, but each resource is handled by a single goroutine/thread in isolation
+	MaxConcurrentReconciles int
+}

--- a/operator/controllers/hbasetenant_controller.go
+++ b/operator/controllers/hbasetenant_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	context "context"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	time "time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -148,8 +149,9 @@ func (r *HbaseTenantReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *HbaseTenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *HbaseTenantReconciler) SetupWithManager(mgr ctrl.Manager, opts Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: opts.MaxConcurrentReconciles}). // multiple CRs processing in parallel, while one CR handled by single go routine
 		For(&kvstorev1.HbaseTenant{}).
 		Owns(&appsv1.StatefulSet{}).
 		Complete(r)

--- a/operator/main.go
+++ b/operator/main.go
@@ -81,11 +81,15 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var maxReconcilersTenant int
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.IntVar(&maxReconcilersTenant, "max-reconcilers-tenant", 3, "Max concurrent reconcilers for hbase tenant controller. Default is 3.")
+
 	opts := zap.Options{
 		Development: true,
 	}
@@ -128,7 +132,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("HbaseTenant"),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, controllers.Options{MaxConcurrentReconciles: maxReconcilersTenant}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HbaseTenant")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Context: increasing concurrency to reconcile multiple CRs.

Refer: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller#TypedOptions