### PR TITLE
YAK-2922 CRD and chart update for sa for nn fencing

### DIFF
--- a/examples/hbasecluster-chart/Chart.yaml
+++ b/examples/hbasecluster-chart/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "1.16.0"
 
 dependencies:
 - name: hbase-chart
-  version: 1.0.41
+  version: 1.0.42
   repository: https://github.com/flipkart-incubator/hbase-k8s-operator/helm-charts

--- a/examples/hbasecluster-chart/values.yaml
+++ b/examples/hbasecluster-chart/values.yaml
@@ -1,9 +1,16 @@
 namespace: hbase-cluster-ns
-serviceAccountName: hbase-operator-controller-manager
+serviceAccounts:
+  operatorServiceAccount: hbase-operator-controller-manager
+  fencingServiceAccount: namenode-fencing
+roles:
+  operatorRoleKind: Role
+  operatorRoleName: hbase-operator-manager-role
+  fencingRoleKind: Role
+  fencingRoleName: namenode-fencing-role
+roleBindings:
+  fencingRoleBindingName: namenode-fencing-rolebinding
+  operatorRoleBindingName: hbase-operator-manager-rolebinding
 sharedWithOperatorNamespace: false
-managerRoleKind: Role
-managerRoleName: hbase-operator-manager-role
-managerRoleBindingName: hbase-operator-manager-rolebinding
 operatorNamespace: hbase-operator-ns
 service:
   name: hbase-cluster

--- a/examples/hbasecluster-chart/values.yaml
+++ b/examples/hbasecluster-chart/values.yaml
@@ -1,17 +1,17 @@
 namespace: hbase-cluster-ns
+managerServiceAccountName: hbase-operator-controller-manager
+managerRoleKind: Role
+managerRoleName: hbase-operator-manager-role
+managerRoleBindingName: hbase-operator-manager-rolebinding
+sharedWithOperatorNamespace: false
+operatorNamespace: hbase-operator-ns
 serviceAccounts:
-  operatorServiceAccount: hbase-operator-controller-manager
   fencingServiceAccount: namenode-fencing
 roles:
-  operatorRoleKind: Role
-  operatorRoleName: hbase-operator-manager-role
   fencingRoleKind: Role
   fencingRoleName: namenode-fencing-role
 roleBindings:
   fencingRoleBindingName: namenode-fencing-rolebinding
-  operatorRoleBindingName: hbase-operator-manager-rolebinding
-sharedWithOperatorNamespace: false
-operatorNamespace: hbase-operator-ns
 service:
   name: hbase-cluster
   image: hbase:2.4.12

--- a/examples/hbasecluster-chart/values.yaml
+++ b/examples/hbasecluster-chart/values.yaml
@@ -1,11 +1,11 @@
 namespace: hbase-cluster-ns
-managerServiceAccountName: hbase-operator-controller-manager
+serviceAccountName: hbase-operator-controller-manager
+sharedWithOperatorNamespace: false
 managerRoleKind: Role
 managerRoleName: hbase-operator-manager-role
 managerRoleBindingName: hbase-operator-manager-rolebinding
-sharedWithOperatorNamespace: false
 operatorNamespace: hbase-operator-ns
-serviceAccounts:
+additionalServiceAccounts:
   fencingServiceAccount: namenode-fencing
 roles:
   fencingRoleKind: Role

--- a/examples/hbasestandalone-chart/Chart.yaml
+++ b/examples/hbasestandalone-chart/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "1.16.0"
 
 dependencies:
 - name: hbase-chart
-  version: 1.0.41
+  version: 1.0.42
   repository: https://github.com/flipkart-incubator/hbase-k8s-operator/helm-charts

--- a/examples/hbasestandalone-chart/values.yaml
+++ b/examples/hbasestandalone-chart/values.yaml
@@ -1,13 +1,13 @@
 namespace: hbase-standalone-ns
-serviceAccounts:
-  operatorServiceAccount: hbase-operator-controller-manager
-roles:
-  operatorRoleKind: Role
-  operatorRoleName: hbase-operator-manager-role
-roleBindings:
-  operatorRoleBindingName: hbase-operator-manager-rolebinding
+managerServiceAccountName: hbase-operator-controller-manager
+managerRoleKind: Role
+managerRoleName: hbase-operator-manager-role
+managerRoleBindingName: hbase-operator-manager-rolebinding
 sharedWithOperatorNamespace: false
 operatorNamespace: hbase-operator-ns
+serviceAccounts: {}
+roles: {}
+roleBindings: {}
 service:
   name: hbase-standalone
   image: hbase:2.4.12

--- a/examples/hbasestandalone-chart/values.yaml
+++ b/examples/hbasestandalone-chart/values.yaml
@@ -1,9 +1,12 @@
 namespace: hbase-standalone-ns
-serviceAccountName: hbase-operator-controller-manager
+serviceAccounts:
+  operatorServiceAccount: hbase-operator-controller-manager
+roles:
+  operatorRoleKind: Role
+  operatorRoleName: hbase-operator-manager-role
+roleBindings:
+  operatorRoleBindingName: hbase-operator-manager-rolebinding
 sharedWithOperatorNamespace: false
-managerRoleKind: Role
-managerRoleName: hbase-operator-manager-role
-managerRoleBindingName: hbase-operator-manager-rolebinding
 operatorNamespace: hbase-operator-ns
 service:
   name: hbase-standalone

--- a/examples/hbasestandalone-chart/values.yaml
+++ b/examples/hbasestandalone-chart/values.yaml
@@ -1,11 +1,11 @@
 namespace: hbase-standalone-ns
-managerServiceAccountName: hbase-operator-controller-manager
+serviceAccountName: hbase-operator-controller-manager
+sharedWithOperatorNamespace: false
 managerRoleKind: Role
 managerRoleName: hbase-operator-manager-role
 managerRoleBindingName: hbase-operator-manager-rolebinding
-sharedWithOperatorNamespace: false
 operatorNamespace: hbase-operator-ns
-serviceAccounts: {}
+additionalServiceAccounts: {}
 roles: {}
 roleBindings: {}
 service:

--- a/examples/hbasetenant-chart/Chart.yaml
+++ b/examples/hbasetenant-chart/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "1.16.0"
 
 dependencies:
 - name: hbase-chart
-  version: 1.0.41
+  version: 1.0.42
   repository: https://github.com/flipkart-incubator/hbase-k8s-operator/helm-charts

--- a/examples/hbasetenant-chart/values.yaml
+++ b/examples/hbasetenant-chart/values.yaml
@@ -1,13 +1,13 @@
 namespace: hbase-tenant-ns
-serviceAccounts:
-  operatorServiceAccount: hbase-operator-controller-manager
-roles:
-  operatorRoleKind: Role
-  operatorRoleName: hbase-operator-manager-role
-roleBindings:
-  operatorRoleBindingName: hbase-operator-manager-rolebinding
+managerServiceAccountName: hbase-operator-controller-manager
+managerRoleKind: Role
+managerRoleName: hbase-operator-manager-role
+managerRoleBindingName: hbase-operator-manager-rolebinding
 sharedWithOperatorNamespace: false
 operatorNamespace: hbase-operator-ns
+serviceAccounts: {}
+roles: {}
+roleBindings: {}
 service:
   name: hbase-tenant
   image: hbase:2.4.12

--- a/examples/hbasetenant-chart/values.yaml
+++ b/examples/hbasetenant-chart/values.yaml
@@ -1,9 +1,12 @@
 namespace: hbase-tenant-ns
-serviceAccountName: hbase-operator-controller-manager
+serviceAccounts:
+  operatorServiceAccount: hbase-operator-controller-manager
+roles:
+  operatorRoleKind: Role
+  operatorRoleName: hbase-operator-manager-role
+roleBindings:
+  operatorRoleBindingName: hbase-operator-manager-rolebinding
 sharedWithOperatorNamespace: false
-managerRoleKind: Role
-managerRoleName: hbase-operator-manager-role
-managerRoleBindingName: hbase-operator-manager-rolebinding
 operatorNamespace: hbase-operator-ns
 service:
   name: hbase-tenant

--- a/examples/hbasetenant-chart/values.yaml
+++ b/examples/hbasetenant-chart/values.yaml
@@ -1,11 +1,11 @@
 namespace: hbase-tenant-ns
-managerServiceAccountName: hbase-operator-controller-manager
+serviceAccountName: hbase-operator-controller-manager
+sharedWithOperatorNamespace: false
 managerRoleKind: Role
 managerRoleName: hbase-operator-manager-role
 managerRoleBindingName: hbase-operator-manager-rolebinding
-sharedWithOperatorNamespace: false
 operatorNamespace: hbase-operator-ns
-serviceAccounts: {}
+additionalServiceAccounts: {}
 roles: {}
 roleBindings: {}
 service:

--- a/helm-charts/hbase-chart/Chart.yaml
+++ b/helm-charts/hbase-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.41
+version: 1.0.42
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/hbase-chart/templates/_hbasecluster.tpl
+++ b/helm-charts/hbase-chart/templates/_hbasecluster.tpl
@@ -1,4 +1,10 @@
 {{ define "com.flipkart.hbasecluster" }}
+{{- include "com.flipkart.hbasecluster.roles" . }}
+---
+{{- include "com.flipkart.hbasecluster.rolebindings" . }}
+---
+{{- include "com.flipkart.hbasecluster.serviceaccounts" . }}
+---
 {{- if eq .Values.sharedWithOperatorNamespace true }}
 ---
 {{- else }}

--- a/helm-charts/hbase-chart/templates/_rolebindings.yaml
+++ b/helm-charts/hbase-chart/templates/_rolebindings.yaml
@@ -10,7 +10,7 @@ roleRef:
   name: {{ .Values.managerRoleName }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.managerServiceAccountName }}
+  name: {{ .Values.serviceAccountName }}
   namespace: {{ .Values.operatorNamespace }}
 {{ end }}
 

--- a/helm-charts/hbase-chart/templates/_rolebindings.yaml
+++ b/helm-charts/hbase-chart/templates/_rolebindings.yaml
@@ -2,14 +2,32 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.managerRoleBindingName }}
+  name:{{ .Values.roleBindings.operatorRoleBindingName }}
   namespace: {{ .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: {{ default "Role" .Values.managerRoleKind }}
-  name: {{ .Values.managerRoleName }}
+  kind: {{ default "Role" .Values.roles.operatorRoleKind }}
+  name: {{ .Values.roles.operatorRoleName }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccountName }}
+  name: {{ .Values.serviceAccounts.operatorServiceAccount }}
   namespace: {{ .Values.operatorNamespace }}
+{{ end }}
+
+---
+
+{{ define "com.flipkart.hbasecluster.rolebindings" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.roleBindings.fencingRoleBindingName }}
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ default "Role" .Values.roles.fencingRoleKind }}
+  name: {{ .Values.roles.fencingRoleName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccounts.fencingServiceAccount }}
+    namespace: {{ .Values.namespace }}
 {{ end }}

--- a/helm-charts/hbase-chart/templates/_rolebindings.yaml
+++ b/helm-charts/hbase-chart/templates/_rolebindings.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name:{{ .Values.roleBindings.operatorRoleBindingName }}
+  name: {{ .Values.roleBindings.operatorRoleBindingName }}
   namespace: {{ .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/helm-charts/hbase-chart/templates/_rolebindings.yaml
+++ b/helm-charts/hbase-chart/templates/_rolebindings.yaml
@@ -2,15 +2,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.roleBindings.operatorRoleBindingName }}
+  name: {{ .Values.managerRoleBindingName }}
   namespace: {{ .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: {{ default "Role" .Values.roles.operatorRoleKind }}
-  name: {{ .Values.roles.operatorRoleName }}
+  kind: {{ default "Role" .Values.managerRoleKind }}
+  name: {{ .Values.managerRoleName }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccounts.operatorServiceAccount }}
+  name: {{ .Values.managerServiceAccountName }}
   namespace: {{ .Values.operatorNamespace }}
 {{ end }}
 

--- a/helm-charts/hbase-chart/templates/_roles.yaml
+++ b/helm-charts/hbase-chart/templates/_roles.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: {{ .Values.roles.operatorRoleName }}
+  name: {{ .Values.managerRoleName }}
   namespace: {{ .Values.namespace }}
 rules:
 - apiGroups:

--- a/helm-charts/hbase-chart/templates/_roles.yaml
+++ b/helm-charts/hbase-chart/templates/_roles.yaml
@@ -136,7 +136,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: {{ .Values.roles.fencingRoleName }}
   namespace: {{ .Values.namespace }}
 rules:

--- a/helm-charts/hbase-chart/templates/_roles.yaml
+++ b/helm-charts/hbase-chart/templates/_roles.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: {{ .Values.managerRoleName }}
+  name: {{ .Values.roles.operatorRoleName }}
   namespace: {{ .Values.namespace }}
 rules:
 - apiGroups:
@@ -128,4 +128,22 @@ rules:
   - get
   - patch
   - update
+{{ end }}
+
+---
+
+{{- define "com.flipkart.hbasecluster.roles" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: {{ .Values.roles.fencingRoleName }}
+  namespace: {{ .Values.namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
 {{ end }}

--- a/helm-charts/hbase-chart/templates/_serviceaccount.yaml
+++ b/helm-charts/hbase-chart/templates/_serviceaccount.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccounts.fencingServiceAccount }}
+  name: {{ .Values.additionalServiceAccounts.fencingServiceAccount }}
   namespace: {{ .Values.namespace }}
 {{- end }}

--- a/helm-charts/hbase-chart/templates/_serviceaccount.yaml
+++ b/helm-charts/hbase-chart/templates/_serviceaccount.yaml
@@ -1,0 +1,7 @@
+{{- define "com.flipkart.hbasecluster.serviceaccounts" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccounts.fencingServiceAccount }}
+  namespace: {{ .Values.namespace }}
+{{- end }}

--- a/helm-charts/hbase-chart/templates/meta/_component.tpl
+++ b/helm-charts/hbase-chart/templates/meta/_component.tpl
@@ -3,6 +3,7 @@
   size: {{ .root.replicas }}
   isPodServiceRequired: {{ default false .root.isPodServiceRequired }}
   shareProcessNamespace: {{ default false .root.shareProcessNamespace }}
+  serviceAccountName: {{ default "default" .root.serviceAccountName }}
   {{- if .root.podManagementPolicy }}
   podManagementPolicy: {{ .root.podManagementPolicy }}
   {{- else if $.podManagementPolicy }}

--- a/operator/api/v1/hbasecluster_types.go
+++ b/operator/api/v1/hbasecluster_types.go
@@ -181,6 +181,8 @@ type HbaseClusterDeployment struct {
 	TopologySpreadConstraint []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty" patchStrategy:"merge" patchMergeKey:"topologyKey" protobuf:"bytes,33,opt,name=topologySpreadConstraints"`
 	// +optional
 	PodDisruptionBudget *HBasePodDisruptionBudget `json:"podDisruptionBudget,omitempty"`
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 type HbaseClusterConfiguration struct {

--- a/operator/config/crd/bases/kvstore.flipkart.com_hbaseclusters.yaml
+++ b/operator/config/crd/bases/kvstore.flipkart.com_hbaseclusters.yaml
@@ -390,6 +390,8 @@ spec:
                         - Parallel
                         - OrderedReady
                         type: string
+                      serviceAccountName:
+                        type: string
                       shareProcessNamespace:
                         default: false
                         type: boolean
@@ -925,6 +927,8 @@ spec:
                         enum:
                         - Parallel
                         - OrderedReady
+                        type: string
+                      serviceAccountName:
                         type: string
                       shareProcessNamespace:
                         default: false
@@ -1462,6 +1466,8 @@ spec:
                         - Parallel
                         - OrderedReady
                         type: string
+                      serviceAccountName:
+                        type: string
                       shareProcessNamespace:
                         default: false
                         type: boolean
@@ -1998,6 +2004,8 @@ spec:
                         - Parallel
                         - OrderedReady
                         type: string
+                      serviceAccountName:
+                        type: string
                       shareProcessNamespace:
                         default: false
                         type: boolean
@@ -2533,6 +2541,8 @@ spec:
                         enum:
                         - Parallel
                         - OrderedReady
+                        type: string
+                      serviceAccountName:
                         type: string
                       shareProcessNamespace:
                         default: false

--- a/operator/config/crd/bases/kvstore.flipkart.com_hbasestandalones.yaml
+++ b/operator/config/crd/bases/kvstore.flipkart.com_hbasestandalones.yaml
@@ -399,6 +399,8 @@ spec:
                     - Parallel
                     - OrderedReady
                     type: string
+                  serviceAccountName:
+                    type: string
                   shareProcessNamespace:
                     default: false
                     type: boolean

--- a/operator/config/crd/bases/kvstore.flipkart.com_hbasetenants.yaml
+++ b/operator/config/crd/bases/kvstore.flipkart.com_hbasetenants.yaml
@@ -387,6 +387,8 @@ spec:
                     - Parallel
                     - OrderedReady
                     type: string
+                  serviceAccountName:
+                    type: string
                   shareProcessNamespace:
                     default: false
                     type: boolean

--- a/operator/controllers/utils.go
+++ b/operator/controllers/utils.go
@@ -519,6 +519,7 @@ func buildStatefulSet(name string, namespace string, baseImage string, isBootstr
 					SecurityContext: &corev1.PodSecurityContext{
 						FSGroup: &fsgroup,
 					},
+					ServiceAccountName:            d.ServiceAccountName,
 					ShareProcessNamespace:         &d.ShareProcessNamespace,
 					TerminationGracePeriodSeconds: &d.TerminationGracePeriodSeconds,
 					Volumes:                       buildVolumes(configuration, d.Volumes),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying custom service account names for various HBase deployment roles, including datanode, hmaster, journalnode, namenode, zookeeper, standalone, and tenant datanode components.

- **Refactor**
  - Restructured Helm chart values for service accounts, roles, and role bindings into grouped sections for improved clarity and modularity.
  - Enhanced Helm templates to include additional roles, role bindings, and service accounts for HBase cluster components.
  - Updated pod specifications to use the specified service account names for deployments.

- **Chores**
  - Updated Helm chart and dependency versions to 1.0.42.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->