### PR TITLE
Yak Cluster Observer Rolebinding adding to hbase cluster and tenant template for KaaS service

### DIFF
--- a/examples/hbasecluster-chart/Chart.yaml
+++ b/examples/hbasecluster-chart/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "1.16.0"
 
 dependencies:
 - name: hbase-chart
-  version: 1.0.41
+  version: 1.0.42
   repository: https://github.com/flipkart-incubator/hbase-k8s-operator/helm-charts

--- a/examples/hbasecluster-chart/values.yaml
+++ b/examples/hbasecluster-chart/values.yaml
@@ -5,6 +5,13 @@ managerRoleKind: Role
 managerRoleName: hbase-operator-manager-role
 managerRoleBindingName: hbase-operator-manager-rolebinding
 operatorNamespace: hbase-operator-ns
+serviceAccounts:
+  observerServiceAccount: hbase-cluster-observer
+roles:
+  observerRoleKind: Role
+  observerRoleName: hbase-cluster-observer-role
+roleBindings:
+  observerRoleBindingName: observer-rolebinding
 service:
   name: hbase-cluster
   image: hbase:2.4.12

--- a/examples/hbasestandalone-chart/Chart.yaml
+++ b/examples/hbasestandalone-chart/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "1.16.0"
 
 dependencies:
 - name: hbase-chart
-  version: 1.0.41
+  version: 1.0.42
   repository: https://github.com/flipkart-incubator/hbase-k8s-operator/helm-charts

--- a/examples/hbasestandalone-chart/values.yaml
+++ b/examples/hbasestandalone-chart/values.yaml
@@ -5,6 +5,9 @@ managerRoleKind: Role
 managerRoleName: hbase-operator-manager-role
 managerRoleBindingName: hbase-operator-manager-rolebinding
 operatorNamespace: hbase-operator-ns
+serviceAccounts: {}
+roles: {}
+roleBindings: {}
 service:
   name: hbase-standalone
   image: hbase:2.4.12

--- a/examples/hbasetenant-chart/Chart.yaml
+++ b/examples/hbasetenant-chart/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "1.16.0"
 
 dependencies:
 - name: hbase-chart
-  version: 1.0.41
+  version: 1.0.42
   repository: https://github.com/flipkart-incubator/hbase-k8s-operator/helm-charts

--- a/examples/hbasetenant-chart/values.yaml
+++ b/examples/hbasetenant-chart/values.yaml
@@ -5,6 +5,13 @@ managerRoleKind: Role
 managerRoleName: hbase-operator-manager-role
 managerRoleBindingName: hbase-operator-manager-rolebinding
 operatorNamespace: hbase-operator-ns
+serviceAccounts:
+  observerServiceAccount: hbase-cluster-observer
+roles:
+  observerRoleKind: Role
+  observerRoleName: hbase-cluster-observer-role
+roleBindings:
+  observerRoleBindingName: observer-rolebinding
 service:
   name: hbase-tenant
   image: hbase:2.4.12

--- a/helm-charts/hbase-chart/templates/_hbasecluster.tpl
+++ b/helm-charts/hbase-chart/templates/_hbasecluster.tpl
@@ -1,4 +1,5 @@
 {{ define "com.flipkart.hbasecluster" }}
+{{- include "com.flipkart.hbasecluster.rolebindings" . }}
 {{- if eq .Values.sharedWithOperatorNamespace true }}
 ---
 {{- else }}

--- a/helm-charts/hbase-chart/templates/_rolebindings.yaml
+++ b/helm-charts/hbase-chart/templates/_rolebindings.yaml
@@ -13,3 +13,21 @@ subjects:
   name: {{ .Values.serviceAccountName }}
   namespace: {{ .Values.operatorNamespace }}
 {{ end }}
+
+---
+
+{{ define "com.flipkart.hbasecluster.rolebindings" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.roleBindings.observerRoleBindingName }}
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ default "Role" .Values.roles.observerRoleKind }}
+  name: {{ .Values.roles.observerRoleName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccounts.observerServiceAccount }}
+    namespace: {{ .Values.namespace }}
+{{ end }}


### PR DESCRIPTION
Kubernetes as a Service component needs a role binding on every tenant and core namespace to fetch the resources of the cluster. This rolebinding has to be added to the template and the template needs to be imported into the Hbase cluster CRD.