### PR TITLE
heapdump path configuration

### DIFF
--- a/helm-charts/hbase-chart/templates/meta/_hmasterscript.tpl
+++ b/helm-charts/hbase-chart/templates/meta/_hmasterscript.tpl
@@ -5,6 +5,9 @@ export HBASE_LOG_DIR=$0
 export HBASE_CONF_DIR=$1
 export HBASE_HOME=$2
 export USER=$(whoami)
+{{- if .Values.configuration.hbaseHeapDumpPath }}
+export HBASE_HEAPDUMP_PATH="{{ .Values.configuration.hbaseHeapDumpPath }}"
+{{- end }}
 
 mkdir -p $HBASE_LOG_DIR
 touch $HBASE_LOG_DIR/hbase-$USER-master-$(hostname).log && tail -F $HBASE_LOG_DIR/hbase-$USER-master-$(hostname).log &

--- a/helm-charts/hbase-chart/templates/meta/_rsscript.tpl
+++ b/helm-charts/hbase-chart/templates/meta/_rsscript.tpl
@@ -5,6 +5,9 @@ export HBASE_LOG_DIR=$0
 export HBASE_CONF_DIR=$1
 export HBASE_HOME=$2
 export USER=$(whoami)
+{{- if .Values.configuration.hbaseHeapDumpPath }}
+export HBASE_HEAPDUMP_PATH="{{ .Values.configuration.hbaseHeapDumpPath }}"
+{{- end }}
 
 FAULT_DOMAIN_COMMAND=$3
 

--- a/helm-charts/hbase-chart/templates/meta/_zkscript.tpl
+++ b/helm-charts/hbase-chart/templates/meta/_zkscript.tpl
@@ -7,6 +7,9 @@ export HBASE_LOG_DIR=$0
 export HBASE_CONF_DIR=$1
 export HBASE_HOME=$2
 export USER=$(whoami)
+{{- if .Values.configuration.hbaseHeapDumpPath }}
+export HBASE_HEAPDUMP_PATH="{{ .Values.configuration.hbaseHeapDumpPath }}"
+{{- end }}
 
 mkdir -p $HBASE_LOG_DIR
 touch $HBASE_LOG_DIR/hbase-$USER-zookeeper-$(hostname).log &&  tail -F $HBASE_LOG_DIR/hbase-$USER-zookeeper-$(hostname).log &


### PR DESCRIPTION
heapdump path passed to startup script which can be used in hbase-env file to start the process and leverage the heap dump in case of OOM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional heap dump path configuration for HBase and related service startup scripts.
  * When configured, the specified path is automatically applied through the `HBASE_HEAPDUMP_PATH` environment variable.
  * Existing behavior remains unchanged when no path is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->