### PR TITLE
updated master shutdown script

### DIFF
--- a/helm-charts/hbase-chart/templates/meta/_hmasterscript.tpl
+++ b/helm-charts/hbase-chart/templates/meta/_hmasterscript.tpl
@@ -5,20 +5,32 @@ export HBASE_LOG_DIR=$0
 export HBASE_CONF_DIR=$1
 export HBASE_HOME=$2
 export USER=$(whoami)
-{{- if .Values.configuration.hbaseHeapDumpPath }}
-export HBASE_HEAPDUMP_PATH="{{ .Values.configuration.hbaseHeapDumpPath }}"
-{{- end }}
 
 mkdir -p $HBASE_LOG_DIR
 touch $HBASE_LOG_DIR/hbase-$USER-master-$(hostname).log && tail -F $HBASE_LOG_DIR/hbase-$USER-master-$(hostname).log &
 touch $HBASE_LOG_DIR/hbase-$USER-master-$(hostname).out && tail -F $HBASE_LOG_DIR/hbase-$USER-master-$(hostname).out &
 
 function shutdown() {
+  # Graceful stop: SIGTERM the master JVM and wait until it exits so
+  # ActiveMasterManager can delete /hbase/master (or close the ZK session)
+  # before this container dies. Without waiting, kubelet SIGKILLs the JVM
+  # and backup waits ~zookeeper.session.timeout (~60s) for failover.
   echo "Stopping Hmaster"
-  $HBASE_HOME/bin/hbase-daemon.sh stop master
+  MPID=$(ps -eo pid,args | awk '/[D]proc_master/ {print $1; exit}')
+  if [ -n "$MPID" ]; then
+    kill -TERM "$MPID"
+    echo "Sent SIGTERM to master JVM pid=$MPID; waiting for exit"
+    while kill -0 "$MPID" 2>/dev/null; do
+      sleep 1
+    done
+    echo "Hmaster JVM exited"
+  else
+    echo "Master JVM not found; falling back to hbase-daemon.sh stop master"
+    $HBASE_HOME/bin/hbase-daemon.sh stop master
+  fi
 }
 
-trap shutdown SIGTERM
+trap shutdown SIGTERM SIGINT
 exec $HBASE_HOME/bin/hbase-daemon.sh foreground_start master &
 wait
 {{- end }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved service shutdown reliability by allowing the master process to terminate cleanly before the container exits.
  - Added handling for both standard termination and interrupt requests.
  - Added a fallback shutdown path when the primary process cannot be detected.
  - Removed support for the optional heap dump path configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->